### PR TITLE
Adding some basic TFO server side tests

### DIFF
--- a/fast-open/server/README.md
+++ b/fast-open/server/README.md
@@ -1,0 +1,15 @@
+# Snippets
+
+## Description
+This directory contains files to validate the TCP FastOpen server-side
+
+## Status
+
+| Name                                                                                                 | Result FreeBSD 13.0 | Result FreeBSD Head |
+|:-----------------------------------------------------------------------------------------------------|:-------------------:|:-------------------:|
+|[server-cookie-req](server-cookie-req.pkt "Perform basic TFO cookie request")                         | Unknown             | PASSED (Note 1)     |
+|[server-correct-cookie](server-correct-cookie.pkt "Do a TFO SYN+Data with the correct cookie")        | Unknown             | PASSED (Note 1)     |
+|[server-wrong-cookie](server-wrong-cookie.pkt "Validate SYN data is rejected with wrong cookie")      | Unknown             | PASSED (Note 1)     |
+|[server-data-on-synack](server-data-on-synack "Check if server data is returned on SYN,ACK")          | Unknown             | PASSED (Note 1)     |
+## Notes
+1. Requires the setkey utility provided

--- a/fast-open/server/all-fast-open-server-tests
+++ b/fast-open/server/all-fast-open-server-tests
@@ -1,0 +1,4 @@
+fast-open/server/server-cookie-req
+fast-open/server/server-correct-cookie
+fast-open/server/server-wrong-cookie
+fast-open/server/server-data-on-synack

--- a/fast-open/server/server-cookie-req.pkt
+++ b/fast-open/server/server-cookie-req.pkt
@@ -1,0 +1,72 @@
+//
+// Copyright (c) 2018 Michael Tuexen
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+// SUCH DAMAGE.
+//
+
+// Ensure that when a cookie of length 8 (valid) is provided by the server,
+// it is accepted and used by a follow-up connections even if the server
+// does not send it in followup connections.
+
+--tolerance_usecs=10000
+
+// Ensure that all relevant sysctl variables have their default values.
+ 0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.sack.enable=1`
++0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
++0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`
+
+// Reset the TCP fast open connection cache.
++0.00 `sysctl -w net.inet.tcp.fastopen.psk_enable=0`
++0.00 `sysctl -w net.inet.tcp.fastopen.client_enable=0`
++0.00 `sysctl -w net.inet.tcp.fastopen.client_enable=1`
++0.00 `sysctl -w net.inet.tcp.fastopen.server_enable=0`
++0.00 `sysctl -w net.inet.tcp.fastopen.server_enable=1`
++0.00 `sysctl -w net.inet.tcp.syncookies=0`
++0.00 `if [ ! -e ./setkey ]; then cc -o setkey setkey.c;fi; ./setkey`
+
+// First setup a TCP connection to get a TFO cookie
+// Server should reject any SYN data, due to the wrong cookie
++0.00 socket(..., SOCK_STREAM, IPPROTO_TCP) = 3
++0.00 bind(3, ..., ...) = 0
++0.00 setsockopt(3, IPPROTO_TCP, TCP_FASTOPEN, [1], 4) = 0
++0.00 getsockopt(3, IPPROTO_TCP, TCP_FASTOPEN, [0x80000000], [4]) = 0
++0.00 listen(3, 4) = 0
+ 0.50 < S  0:100(100) win 65535 <mss 1460,nop,wscale 6,sackOK,TS val 1 ecr 0,FO,eol,eol>
++0.00 > S. 0:0(0) ack 1 win 65535 <mss 1460,nop,wscale 6,sackOK,TS val 2 ecr 1,FO 2069a359c930dba9,eol,eol>
++0.00 < P. 1:101(100) ack 1 win 65535 <nop,nop,TS val 3 ecr 2>
++0.04 >  . 1:1(0) ack 101  <nop,nop,TS val 4 ecr 3>
++0.00 accept(3, ..., ...) = 4
++0.00 read(4, ..., 100) = 100
+
+// Tear it down. Let the client initiate the teardown to avoid
+// the server moving into TIMEWAIT state.
++0.00 < F. 101:101(0) ack 1 win 65535 <nop,nop,TS val 5 ecr 4>
++0.00 >  . 1:1(0) ack 102 <nop,nop,TS val 6 ecr 5>
++0.00 close(4) = 0
++0.00 > F. 1:1(0) ack 102 <nop,nop,TS val 7 ecr 5>
++0.05 <  . 102:102(0) ack 2 win 65535 <nop,nop,TS val 8 ecr 7>
+
+// close the first listening socket, and set up a new one
+// for packetdrill to resync seq numbers
++0.00 close(3) = 0

--- a/fast-open/server/server-correct-cookie.pkt
+++ b/fast-open/server/server-correct-cookie.pkt
@@ -1,0 +1,69 @@
+//
+// Copyright (c) 2018 Michael Tuexen
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+// SUCH DAMAGE.
+//
+
+// Ensure that when a cookie of length 8 (valid) is provided by the server,
+// it is accepted and used by a follow-up connections even if the server
+// does not send it in followup connections.
+
+--tolerance_usecs=10000
+
+// Ensure that all relevant sysctl variables have their default values.
+ 0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.sack.enable=1`
++0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
++0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`
+
+// Reset the TCP fast open connection cache.
++0.00 `sysctl -w net.inet.tcp.fastopen.psk_enable=0`
++0.00 `sysctl -w net.inet.tcp.fastopen.client_enable=0`
++0.00 `sysctl -w net.inet.tcp.fastopen.client_enable=1`
++0.00 `sysctl -w net.inet.tcp.fastopen.server_enable=0`
++0.00 `sysctl -w net.inet.tcp.fastopen.server_enable=1`
++0.00 `sysctl -w net.inet.tcp.syncookies=0`
++0.00 `if [ ! -e ./setkey ]; then cc -o setkey setkey.c;fi; ./setkey`
+
++0.00 socket(..., SOCK_STREAM, IPPROTO_TCP) = 5
++0.00 bind(5, ..., ...) = 0
++0.00 setsockopt(5, IPPROTO_TCP, TCP_FASTOPEN, [1], 4) = 0
++0.00 listen(5, 4) = 0
+
+// Now set up a TCP connection with the correct cookie
+// and verify the SYN data is accepted
+ 0.50 < SP 0:100(100) win 65535 <mss 1460,nop,wscale 6,sackOK,TS val 11 ecr 0,FO 2069a359c930dba9,eol,eol>
+// no data pending, wait for delayed ACK timeout
++0.04 > S. 0:0(0) ack 101 win 65535 <mss 1460,nop,wscale 6,sackOK,TS val 12 ecr 11,FO 2069a359c930dba9,eol,eol>
++0.00 < .  101:101(0) ack 1 win 65535 <nop,nop,TS val 13 ecr 12>
++0.00 accept(5, ..., ...) = 6
++0.00 read(6, ..., 100) = 100
+
+// again, close listening socket
++0.00 < F. 101:101(0) ack 1 win 65535 <nop,nop,TS val 14 ecr 12>
++0.00 >  . 1:1(0) ack 102 <nop,nop,TS val 15 ecr 14>
++0.00 close(6) = 0
++0.00 close(5) = 0
++0.00 > F. 1:1(0) ack 102 <nop,nop,TS val 16 ecr 14>
++0.05 <  . 102:102(0) ack 2 win 65535 <nop,nop,TS val 17 ecr 16>
+

--- a/fast-open/server/server-data-on-synack.pkt
+++ b/fast-open/server/server-data-on-synack.pkt
@@ -1,0 +1,68 @@
+//
+// Copyright (c) 2018 Michael Tuexen
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+// SUCH DAMAGE.
+//
+
+// Ensure that when a cookie of length 8 (valid) is provided by the server,
+// it is accepted and used by a follow-up connections even if the server
+// does not send it in followup connections.
+
+--tolerance_usecs=10000
+
+// Ensure that all relevant sysctl variables have their default values.
+ 0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.sack.enable=1`
++0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
++0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`
+
+// Reset the TCP fast open connection cache.
++0.00 `sysctl -w net.inet.tcp.fastopen.psk_enable=0`
++0.00 `sysctl -w net.inet.tcp.fastopen.client_enable=0`
++0.00 `sysctl -w net.inet.tcp.fastopen.client_enable=1`
++0.00 `sysctl -w net.inet.tcp.fastopen.server_enable=0`
++0.00 `sysctl -w net.inet.tcp.fastopen.server_enable=1`
++0.00 `sysctl -w net.inet.tcp.syncookies=0`
++0.00 `if [ ! -e ./setkey ]; then cc -o setkey setkey.c;fi; ./setkey`
+
+// Now set up a TCP connection with the correct cookie
+// and verify the SYN data is accepted
++0.00 socket(..., SOCK_STREAM, IPPROTO_TCP) = 9
++0.00 bind(9, ..., ...) = 0
++0.00 setsockopt(9, IPPROTO_TCP, TCP_FASTOPEN, [1], 4) = 0
++0.00 fcntl(9, F_SETFL, O_RDWR | O_NONBLOCK) = 0
++0.00 listen(9, 4) = 0
+ 0.50 < SP 0:100(100) win 65535 <mss 1460,nop,wscale 6,sackOK,TS val 31 ecr 0,FO 2069a359c930dba9,eol,eol>
++0.00 accept(9, ..., ...) = 10
++0.02 write(10, ..., 200) = 200
++0.00 > S. 0:200(200) ack 101 win 65535 <mss 1460,nop,wscale 6,sackOK,TS val 32 ecr 31,FO 2069a359c930dba9,eol,eol>
++0.00 < .  101:101(0) ack 201 win 65535 <nop,nop,TS val 33 ecr 32>
++0.00 read(10, ..., 100) = 100
+
+// Close listening socket
++0.00 < F. 101:101(0) ack 201 win 65535 <nop,nop,TS val 34 ecr 32>
++0.00 >  . 201:201(0) ack 102 <nop,nop,TS val 35 ecr 34>
++0.00 close(9) = 0
++0.00 close(10) = 0
++0.00 > F. 201:201(0) ack 102 <nop,nop,TS val 36 ecr 34>
++0.05 <  . 102:102(0) ack 202 win 65535 <nop,nop,TS val 37 ecr 36>

--- a/fast-open/server/server-wrong-cookie.pkt
+++ b/fast-open/server/server-wrong-cookie.pkt
@@ -1,0 +1,68 @@
+//
+// Copyright (c) 2018 Michael Tuexen
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+// SUCH DAMAGE.
+//
+
+// Ensure that when a cookie of length 8 (valid) is provided by the server,
+// it is accepted and used by a follow-up connections even if the server
+// does not send it in followup connections.
+
+--tolerance_usecs=10000
+
+// Ensure that all relevant sysctl variables have their default values.
+ 0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.sack.enable=1`
++0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
++0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`
+
+// Reset the TCP fast open connection cache.
++0.00 `sysctl -w net.inet.tcp.fastopen.psk_enable=0`
++0.00 `sysctl -w net.inet.tcp.fastopen.client_enable=0`
++0.00 `sysctl -w net.inet.tcp.fastopen.client_enable=1`
++0.00 `sysctl -w net.inet.tcp.fastopen.server_enable=0`
++0.00 `sysctl -w net.inet.tcp.fastopen.server_enable=1`
++0.00 `sysctl -w net.inet.tcp.syncookies=0`
++0.00 `if [ ! -e ./setkey ]; then cc -o setkey setkey.c;fi; ./setkey`
+
+// wrong cookie
+// Set up a TCP connection providing a wrong cookie
++0.00 socket(..., SOCK_STREAM, IPPROTO_TCP) = 7
++0.00 bind(7, ..., ...) = 0
++0.00 setsockopt(7, IPPROTO_TCP, TCP_FASTOPEN, [1], 4) = 0
++0.00 listen(7, 4) = 0
+ 0.50 < S  0:100(100) win 65535 <mss 1460,nop,wscale 6,sackOK,TS val 21 ecr 0,FO 0001020304050607,eol,eol>
+// because of the wrong cookie, SYN,ACK is sent immediately
++0.00 > S. 0:0(0) ack 1 win 65535 <mss 1460,nop,wscale 6,sackOK,TS val 22 ecr 21,FO 2069a359c930dba9,eol,eol>
++0.00 < P. 1:101(100) ack 1 win 65535 <nop,nop,TS val 23 ecr 22>
++0.04 >  . 1:1(0) ack 101  <nop,nop,TS val 24 ecr 23>
++0.00 accept(7, ..., ...) = 8
++0.00 read(8, ..., 100) = 100
+
+// again, close listening socket
++0.00 < F. 101:101(0) ack 1 win 65535 <nop,nop,TS val 24 ecr 22>
++0.00 >  . 1:1(0) ack 102 <nop,nop,TS val 25 ecr 24>
++0.00 close(7) = 0
++0.00 close(8) = 0
++0.00 > F. 1:1(0) ack 102 <nop,nop,TS val 26 ecr 24>
++0.05 <  . 102:102(0) ack 2 win 65535 <nop,nop,TS val 27 ecr 26>

--- a/fast-open/server/setkey.c
+++ b/fast-open/server/setkey.c
@@ -1,0 +1,16 @@
+/*
+ * A simple program to set the CTLTYPE_OPAQUE
+ * TCP Fastopen key, which can not be set
+ * using the command line sysctl utility.
+ */
+
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+
+int main(int argc, char **argv) {
+        uint8_t key[16] = {0};
+        int error = sysctlbyname("net.inet.tcp.fastopen.setkey", NULL, NULL, &key , sizeof(key));
+        printf("error: %d\n", error);
+}
+


### PR DESCRIPTION
The main trick is to do a listen(..., 4) as only half the queue may respond to TFO.
The other one to provide a small script, setting the current key so that the cookie always has the same value. This can not be done using sysctl(8) since CTLTYPE_OPAQUE can not be set with that utility.