### PR TITLE
icmp: re-run those ICMP messages that are always ignored

### DIFF
--- a/rcv-icmp/rcv-icmp-hard-error-ignored-ipv4.pkt
+++ b/rcv-icmp/rcv-icmp-hard-error-ignored-ipv4.pkt
@@ -98,8 +98,41 @@
 +0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
 +0.00 < icmp unreachable frag_needed mtu 1234 [0:0(0)]
 +0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
+// Enable icmp_may_rst and retry those messages that are always ignored
++0.00 `sysctl -w net.inet.tcp.icmp_may_rst=1`
++0.00 <icmp unreachable net_unreachable [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp unreachable host_unreachable [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp unreachable source_route_failed [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp unreachable net_unknown [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp unreachable host_unknown [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp unreachable source_host_isolated [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp unreachable net_unreachable_for_tos [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp unreachable host_unreachable_for_tos [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp unreachable precedence_violation [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp unreachable precedence_cutoff [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp redirect [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp source_quench [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp time_exceeded frag_reass_exceeded [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp parameter_problem code_0 [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp parameter_problem code_1 [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp parameter_problem code_2 [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
  2.00 > S  0:0(0) win 65535 <mss 1460,nop,wscale 6,sackOK,TS val 1100 ecr 0>
 // Cleanup
 +0.00 `sysctl -w net.inet.tcp.hostcache.purgenow=1`
-+0.00 `sysctl -w net.inet.tcp.icmp_may_rst=1`
 +0.00 close(3) = 0


### PR DESCRIPTION
for a second time, now with net.inet.tcp.icmp_may_rst=1.