### PR TITLE
icmp6: re-run those ICMP messages that are always ignored

### DIFF
--- a/rcv-icmp/rcv-icmp-hard-error-ignored-ipv6.pkt
+++ b/rcv-icmp/rcv-icmp-hard-error-ignored-ipv6.pkt
@@ -75,7 +75,20 @@
 +0.00 < icmp packet_too_big mtu 1300 [0:0(0)]
 +0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
  2.00 > S  0:0(0) win 65535 <mss 1240,nop,wscale 6,sackOK,TS val 1100 ecr 0>
+// Enable icmp_may_rst and retry those messages that are always ignored
++0.00 `sysctl -w net.inet.tcp.icmp_may_rst=1`
++0.00 < icmp unreachable no_route [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp unreachable address_unreachable [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp unreachable not_neighbour [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp time_exceeded exceeded_frag_time [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp parameter_problem header_field [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
++0.00 < icmp parameter_problem unknown_option [0:0(0)]
++0.01 getsockopt(3, SOL_SOCKET, SO_ERROR, [0], [4]) = 0
 // Cleanup
 +0.00 `sysctl -w net.inet.tcp.hostcache.purgenow=1`
-+0.00 `sysctl -w net.inet.tcp.icmp_may_rst=1`
 +0.00 close(3) = 0


### PR DESCRIPTION
for a second time, now with net.inet.tcp.icmp_may_rst=1.