### PR TITLE
run script from local directory

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -25,6 +25,8 @@
 # SUCH DAMAGE.
 #
 
+#pwd=`pwd`
+#rootdir=`/usr/bin/dirname ${pwd}/$0`
 rootdir=`/usr/bin/dirname $0`
 passed=0
 failed=0
@@ -119,8 +121,11 @@ for file ; do
       if [ -t 1 ] ; then
         printf "\033[33m%10s\033[0m" "RUNNING"
       fi
-      timeout $timelimit $packetdrill ${flags} ${rootdir}/${testdir}/${testname}.pkt >${rootdir}/${testdir}/${prefix}${testname}.out 2>&1
+      pwd=`pwd`
+      cd `dirname  ${pwd}/${rootdir}/${testdir}/${testname}.pkt`
+      timeout $timelimit $packetdrill ${flags} ${testname}.pkt > ${prefix}${testname}.out 2>&1
       result=$?
+      cd ${pwd}
       if [ $result -eq 0 -a $verbose -eq 0 ] ; then
         rm ${rootdir}/${testdir}/${prefix}${testname}.out
       fi
@@ -203,6 +208,7 @@ for file ; do
     fi
   done
 done
+cd ${rootdir}
 printf "===============================================================================\n"
 printf "Summary: Number of tests run:                    %3u\n" $run
 printf "         Number of tests passed:                 %3u\n" $passed

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -25,8 +25,6 @@
 # SUCH DAMAGE.
 #
 
-#pwd=`pwd`
-#rootdir=`/usr/bin/dirname ${pwd}/$0`
 rootdir=`/usr/bin/dirname $0`
 passed=0
 failed=0


### PR DESCRIPTION
This allows relative paths to work properly irrespective from where the packetdrill script is invoked from via the script.

Testing scripts would be done from the local directory; relative path execution of a script containing relative paths would still fail.

But within the testing framework, relative paths resolve correctly, with the expected results.