### PR TITLE
Update README.md

### DIFF
--- a/rcv-icmp/README.md
+++ b/rcv-icmp/README.md
@@ -1,6 +1,6 @@
 # Tests for Handling ICMP Messages
 
-##Description
+## Description
 
 This set of tests focuses on the handling of ICMP messages in the `SYN-SENT` state.
 


### PR DESCRIPTION
Fix a minor typo in the `README.md` file, so it can properly render the `<h2>` tag.