### PR TITLE
Ensure that net.inet.tcp.blackhole is disabled

### DIFF
--- a/fast-open/client/client-handle-cookie-reject-of-length-01.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-01.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-02.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-02.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-03.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-03.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-04.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-04.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-05.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-05.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-06.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-06.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-07.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-07.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-08.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-08.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-09.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-09.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-10.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-10.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-11.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-11.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-12.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-12.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-13.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-13.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-14.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-14.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-15.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-15.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-16.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-16.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-17.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-17.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-18.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-18.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-19.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-19.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-20.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-20.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-21.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-21.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-22.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-22.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-23.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-23.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-24.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-24.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-25.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-25.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-26.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-26.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-27.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-27.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-28.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-28.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-29.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-29.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-30.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-30.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-31.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-31.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-32.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-32.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-33.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-33.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-34.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-34.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-35.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-35.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-36.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-36.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-37.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-37.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-reject-of-length-38.pkt
+++ b/fast-open/client/client-handle-cookie-reject-of-length-38.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-01.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-01.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-02.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-02.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-03.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-03.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-04.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-04.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-05.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-05.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-06.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-06.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-07.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-07.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-08.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-08.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-09.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-09.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-10.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-10.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-11.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-11.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-12.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-12.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-13.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-13.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-14.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-14.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-15.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-15.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-16.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-16.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-17.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-17.pkt
@@ -32,6 +32,7 @@ s//
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-18.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-18.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-19.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-19.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-20.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-20.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-21.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-21.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-22.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-22.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-23.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-23.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-24.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-24.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-25.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-25.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-26.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-26.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-27.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-27.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-28.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-28.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-29.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-29.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-30.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-30.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-31.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-31.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-32.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-32.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-33.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-33.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-34.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-34.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-35.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-35.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-36.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-36.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-37.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-37.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-cookie-update-of-length-38.pkt
+++ b/fast-open/client/client-handle-cookie-update-of-length-38.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-01.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-01.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-02.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-02.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-03.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-03.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-04.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-04.pkt
@@ -31,6 +31,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-05.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-05.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-06.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-06.pkt
@@ -31,6 +31,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-07.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-07.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-08.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-08.pkt
@@ -31,6 +31,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-09.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-09.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-10.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-10.pkt
@@ -31,6 +31,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-11.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-11.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-12.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-12.pkt
@@ -31,6 +31,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-13.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-13.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-14.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-14.pkt
@@ -31,6 +31,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-15.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-15.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-16.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-16.pkt
@@ -31,6 +31,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-17.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-17.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-18.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-18.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-19.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-19.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-20.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-20.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-21.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-21.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-22.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-22.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-23.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-23.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-24.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-24.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-25.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-25.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-26.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-26.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-27.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-27.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-28.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-28.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-29.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-29.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-30.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-30.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-31.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-31.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-32.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-32.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-33.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-33.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-34.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-34.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-35.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-35.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-36.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-36.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-37.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-37.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-initial-cookie-of-length-38.pkt
+++ b/fast-open/client/client-handle-initial-cookie-of-length-38.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-handle-server-not-supporting-fast-open.pkt
+++ b/fast-open/client/client-handle-server-not-supporting-fast-open.pkt
@@ -31,6 +31,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/fast-open/client/client-server-not-updating-cookie.pkt
+++ b/fast-open/client/client-server-not-updating-cookie.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/rcv-icmp/rcv-icmp-hard-error-comm-prohibited-ipv4.pkt
+++ b/rcv-icmp/rcv-icmp-hard-error-comm-prohibited-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/rcv-icmp/rcv-icmp-hard-error-comm-prohibited-ipv6.pkt
+++ b/rcv-icmp/rcv-icmp-hard-error-comm-prohibited-ipv6.pkt
@@ -31,6 +31,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/rcv-icmp/rcv-icmp-hard-error-host-prohibited-ipv4.pkt
+++ b/rcv-icmp/rcv-icmp-hard-error-host-prohibited-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/rcv-icmp/rcv-icmp-hard-error-ignored-ipv4.pkt
+++ b/rcv-icmp/rcv-icmp-hard-error-ignored-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/rcv-icmp/rcv-icmp-hard-error-ignored-ipv6.pkt
+++ b/rcv-icmp/rcv-icmp-hard-error-ignored-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/rcv-icmp/rcv-icmp-hard-error-net-prohibited-ipv4.pkt
+++ b/rcv-icmp/rcv-icmp-hard-error-net-prohibited-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/rcv-icmp/rcv-icmp-hard-error-port-unreachable-ipv4.pkt
+++ b/rcv-icmp/rcv-icmp-hard-error-port-unreachable-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/rcv-icmp/rcv-icmp-hard-error-port-unreachable-ipv6.pkt
+++ b/rcv-icmp/rcv-icmp-hard-error-port-unreachable-ipv6.pkt
@@ -31,6 +31,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/rcv-icmp/rcv-icmp-hard-error-proto-unreachable-ipv4.pkt
+++ b/rcv-icmp/rcv-icmp-hard-error-proto-unreachable-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/rcv-icmp/rcv-icmp-hard-error-proto-unreachable-ipv6.pkt
+++ b/rcv-icmp/rcv-icmp-hard-error-proto-unreachable-ipv6.pkt
@@ -31,6 +31,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/rcv-icmp/rcv-icmp-hard-error-ttl-exceeded-ipv4.pkt
+++ b/rcv-icmp/rcv-icmp-hard-error-ttl-exceeded-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/rcv-icmp/rcv-icmp-hard-error-ttl-exceeded-ipv6.pkt
+++ b/rcv-icmp/rcv-icmp-hard-error-ttl-exceeded-ipv6.pkt
@@ -31,6 +31,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snd-syn/snd-syn-mss-inherited-from-mtu-1280-ipv6.pkt
+++ b/snd-syn/snd-syn-mss-inherited-from-mtu-1280-ipv6.pkt
@@ -30,6 +30,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-mss-inherited-from-mtu-65535-ipv4.pkt
+++ b/snd-syn/snd-syn-mss-inherited-from-mtu-65535-ipv4.pkt
@@ -30,6 +30,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-mss-inherited-from-mtu-65535-ipv6.pkt
+++ b/snd-syn/snd-syn-mss-inherited-from-mtu-65535-ipv6.pkt
@@ -30,6 +30,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-mss-inherited-from-mtu-72-ipv4.pkt
+++ b/snd-syn/snd-syn-mss-inherited-from-mtu-72-ipv4.pkt
@@ -30,6 +30,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-mss-inherited-from-mtu-9000-ipv4.pkt
+++ b/snd-syn/snd-syn-mss-inherited-from-mtu-9000-ipv4.pkt
@@ -30,6 +30,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-mss-inherited-from-mtu-9000-ipv6.pkt
+++ b/snd-syn/snd-syn-mss-inherited-from-mtu-9000-ipv6.pkt
@@ -30,6 +30,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-rtx-drop-options-ipv4.pkt
+++ b/snd-syn/snd-syn-rtx-drop-options-ipv4.pkt
@@ -34,6 +34,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-rtx-drop-options-ipv6.pkt
+++ b/snd-syn/snd-syn-rtx-drop-options-ipv6.pkt
@@ -34,6 +34,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-rtx-keepinit-ipv4.pkt
+++ b/snd-syn/snd-syn-rtx-keepinit-ipv4.pkt
@@ -38,6 +38,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-rtx-keepinit-ipv6.pkt
+++ b/snd-syn/snd-syn-rtx-keepinit-ipv6.pkt
@@ -38,6 +38,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-rtx-max-number-ipv4.pkt
+++ b/snd-syn/snd-syn-rtx-max-number-ipv4.pkt
@@ -37,6 +37,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
   0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 + 0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 + 0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 + 0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-rtx-max-number-ipv6.pkt
+++ b/snd-syn/snd-syn-rtx-max-number-ipv6.pkt
@@ -37,6 +37,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
   0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 + 0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 + 0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 + 0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-with-default-options-ipv4.pkt
+++ b/snd-syn/snd-syn-with-default-options-ipv4.pkt
@@ -35,6 +35,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-with-default-options-ipv6.pkt
+++ b/snd-syn/snd-syn-with-default-options-ipv6.pkt
@@ -35,6 +35,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-with-ecn-alt-maxretries-ipv4.pkt
+++ b/snd-syn/snd-syn-with-ecn-alt-maxretries-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-with-ecn-alt-maxretries-ipv6.pkt
+++ b/snd-syn/snd-syn-with-ecn-alt-maxretries-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-with-ecn-ipv4.pkt
+++ b/snd-syn/snd-syn-with-ecn-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-with-ecn-ipv6.pkt
+++ b/snd-syn/snd-syn-with-ecn-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-with-max-ws-ipv4.pkt
+++ b/snd-syn/snd-syn-with-max-ws-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-with-max-ws-ipv6.pkt
+++ b/snd-syn/snd-syn-with-max-ws-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-with-min-ws-ipv4.pkt
+++ b/snd-syn/snd-syn-with-min-ws-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-with-min-ws-ipv6.pkt
+++ b/snd-syn/snd-syn-with-min-ws-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-without-options-ipv4.pkt
+++ b/snd-syn/snd-syn-without-options-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snd-syn/snd-syn-without-options-ipv6.pkt
+++ b/snd-syn/snd-syn-without-options-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-without-sack-and-ws-and-ts-ipv4.pkt
+++ b/snd-syn/snd-syn-without-sack-and-ws-and-ts-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`
@@ -59,4 +60,5 @@
 // Finally cleanup
 +0.00 close(3) = 0
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`

--- a/snd-syn/snd-syn-without-sack-and-ws-and-ts-ipv6.pkt
+++ b/snd-syn/snd-syn-without-sack-and-ws-and-ts-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`
@@ -59,4 +60,5 @@
 // Finally cleanup
 +0.00 close(3) = 0
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`

--- a/snd-syn/snd-syn-without-sack-ipv4.pkt
+++ b/snd-syn/snd-syn-without-sack-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-without-sack-ipv6.pkt
+++ b/snd-syn/snd-syn-without-sack-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_initial=1000`

--- a/snd-syn/snd-syn-without-ws-and-ts-ipv4.pkt
+++ b/snd-syn/snd-syn-without-ws-and-ts-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`
@@ -56,3 +57,4 @@
 // Finally cleanup
 +0.00 close(3) = 0
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`

--- a/snd-syn/snd-syn-without-ws-and-ts-ipv6.pkt
+++ b/snd-syn/snd-syn-without-ws-and-ts-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`
@@ -56,3 +57,4 @@
 // Finally cleanup
 +0.00 close(3) = 0
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`

--- a/snippets/close-wait-ipv4.pkt
+++ b/snippets/close-wait-ipv4.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/close-wait-ipv6.pkt
+++ b/snippets/close-wait-ipv6.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/closed-initially-ipv4.pkt
+++ b/snippets/closed-initially-ipv4.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/closed-initially-ipv6.pkt
+++ b/snippets/closed-initially-ipv6.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/closed-via-last-ack-ipv4.pkt
+++ b/snippets/closed-via-last-ack-ipv4.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/closed-via-last-ack-ipv6.pkt
+++ b/snippets/closed-via-last-ack-ipv6.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/closing-ipv4.pkt
+++ b/snippets/closing-ipv4.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/closing-ipv6.pkt
+++ b/snippets/closing-ipv6.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/established-ipv4.pkt
+++ b/snippets/established-ipv4.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/established-ipv6.pkt
+++ b/snippets/established-ipv6.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/fin-wait-1-ipv4.pkt
+++ b/snippets/fin-wait-1-ipv4.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/fin-wait-1-ipv6.pkt
+++ b/snippets/fin-wait-1-ipv6.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/fin-wait-2-ipv4.pkt
+++ b/snippets/fin-wait-2-ipv4.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/fin-wait-2-ipv6.pkt
+++ b/snippets/fin-wait-2-ipv6.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/last-ack-ipv4.pkt
+++ b/snippets/last-ack-ipv4.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/last-ack-ipv6.pkt
+++ b/snippets/last-ack-ipv6.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/listen-ipv4.pkt
+++ b/snippets/listen-ipv4.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/listen-ipv6.pkt
+++ b/snippets/listen-ipv6.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/noopt-strict-tsopt.pkt
+++ b/snippets/noopt-strict-tsopt.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.tolerate_missing_ts=0`

--- a/snippets/syn-rcvd-via-listen-ipv4.pkt
+++ b/snippets/syn-rcvd-via-listen-ipv4.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/syn-rcvd-via-listen-ipv6.pkt
+++ b/snippets/syn-rcvd-via-listen-ipv6.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/syn-rcvd-via-syn-sent-ipv4-ecn01.pkt
+++ b/snippets/syn-rcvd-via-syn-sent-ipv4-ecn01.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/syn-rcvd-via-syn-sent-ipv4-ecn10.pkt
+++ b/snippets/syn-rcvd-via-syn-sent-ipv4-ecn10.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=1`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/syn-rcvd-via-syn-sent-ipv4-ecn11.pkt
+++ b/snippets/syn-rcvd-via-syn-sent-ipv4-ecn11.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=1`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/syn-rcvd-via-syn-sent-ipv4.pkt
+++ b/snippets/syn-rcvd-via-syn-sent-ipv4.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/syn-rcvd-via-syn-sent-ipv6.pkt
+++ b/snippets/syn-rcvd-via-syn-sent-ipv6.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/syn-sent-ipv4.pkt
+++ b/snippets/syn-sent-ipv4.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/syn-sent-ipv6.pkt
+++ b/snippets/syn-sent-ipv6.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/time-wait-via-closing-ipv4.pkt
+++ b/snippets/time-wait-via-closing-ipv4.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/time-wait-via-closing-ipv6.pkt
+++ b/snippets/time-wait-via-closing-ipv6.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/time-wait-via-fin-wait-1-ipv4.pkt
+++ b/snippets/time-wait-via-fin-wait-1-ipv4.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/time-wait-via-fin-wait-1-ipv6.pkt
+++ b/snippets/time-wait-via-fin-wait-1-ipv6.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/time-wait-via-fin-wait-2-ipv4.pkt
+++ b/snippets/time-wait-via-fin-wait-2-ipv4.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/snippets/time-wait-via-fin-wait-2-ipv6.pkt
+++ b/snippets/time-wait-via-fin-wait-2-ipv6.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/socket-api/getsockopt/socket-api-getsockopt-tcpinfo-ipv4.pkt
+++ b/socket-api/getsockopt/socket-api-getsockopt-tcpinfo-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/socket-api/getsockopt/socket-api-getsockopt-tcpinfo-ipv6.pkt
+++ b/socket-api/getsockopt/socket-api-getsockopt-tcpinfo-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/socket-api/setsockopt/socket-api-setsockopt-hoplimit-active-ipv6.pkt
+++ b/socket-api/setsockopt/socket-api-setsockopt-hoplimit-active-ipv6.pkt
@@ -31,6 +31,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/socket-api/setsockopt/socket-api-setsockopt-hoplimit-passive-ipv6.pkt
+++ b/socket-api/setsockopt/socket-api-setsockopt-hoplimit-passive-ipv6.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/socket-api/setsockopt/socket-api-setsockopt-md5-active-ipv4.pkt
+++ b/socket-api/setsockopt/socket-api-setsockopt-md5-active-ipv4.pkt
@@ -35,6 +35,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/socket-api/setsockopt/socket-api-setsockopt-md5-active-ipv6.pkt
+++ b/socket-api/setsockopt/socket-api-setsockopt-md5-active-ipv6.pkt
@@ -35,6 +35,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/socket-api/setsockopt/socket-api-setsockopt-md5-passive-ipv4.pkt
+++ b/socket-api/setsockopt/socket-api-setsockopt-md5-passive-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/socket-api/setsockopt/socket-api-setsockopt-md5-passive-ipv6.pkt
+++ b/socket-api/setsockopt/socket-api-setsockopt-md5-passive-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/socket-api/setsockopt/socket-api-setsockopt-tos-active-ipv4.pkt
+++ b/socket-api/setsockopt/socket-api-setsockopt-tos-active-ipv4.pkt
@@ -31,6 +31,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/socket-api/setsockopt/socket-api-setsockopt-tos-passive-ipv4.pkt
+++ b/socket-api/setsockopt/socket-api-setsockopt-tos-passive-ipv4.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/socket-api/setsockopt/socket-api-setsockopt-traffic-class-active-ipv6.pkt
+++ b/socket-api/setsockopt/socket-api-setsockopt-traffic-class-active-ipv6.pkt
@@ -31,6 +31,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/socket-api/setsockopt/socket-api-setsockopt-traffic-class-passive-ipv6.pkt
+++ b/socket-api/setsockopt/socket-api-setsockopt-traffic-class-passive-ipv6.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/socket-api/setsockopt/socket-api-setsockopt-ttl-active-ipv4.pkt
+++ b/socket-api/setsockopt/socket-api-setsockopt-ttl-active-ipv4.pkt
@@ -31,6 +31,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/socket-api/setsockopt/socket-api-setsockopt-ttl-passive-ipv4.pkt
+++ b/socket-api/setsockopt/socket-api-setsockopt-ttl-passive-ipv4.pkt
@@ -29,6 +29,7 @@
 
 // Ensure that all relevant sysctl variables have their default variables.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.rexmit_slop=200`

--- a/state-event-engine/rcv-ack-closed/rcv-ack-with-data-closed-ipv4.pkt
+++ b/state-event-engine/rcv-ack-closed/rcv-ack-with-data-closed-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-closed/rcv-ack-with-data-closed-ipv6.pkt
+++ b/state-event-engine/rcv-ack-closed/rcv-ack-with-data-closed-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-closed/rcv-ack-without-data-closed-ipv4.pkt
+++ b/state-event-engine/rcv-ack-closed/rcv-ack-without-data-closed-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-closed/rcv-ack-without-data-closed-ipv6.pkt
+++ b/state-event-engine/rcv-ack-closed/rcv-ack-without-data-closed-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-listen/rcv-ack-with-data-listen-ipv4.pkt
+++ b/state-event-engine/rcv-ack-listen/rcv-ack-with-data-listen-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-listen/rcv-ack-with-data-listen-ipv6.pkt
+++ b/state-event-engine/rcv-ack-listen/rcv-ack-with-data-listen-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-listen/rcv-ack-without-data-listen-ipv4.pkt
+++ b/state-event-engine/rcv-ack-listen/rcv-ack-without-data-listen-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-listen/rcv-ack-without-data-listen-ipv6.pkt
+++ b/state-event-engine/rcv-ack-listen/rcv-ack-without-data-listen-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-syn-sent/rcv-ack-with-data-syn-sent-ack-left-edge-ipv4.pkt
+++ b/state-event-engine/rcv-ack-syn-sent/rcv-ack-with-data-syn-sent-ack-left-edge-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-syn-sent/rcv-ack-with-data-syn-sent-ack-left-edge-ipv6.pkt
+++ b/state-event-engine/rcv-ack-syn-sent/rcv-ack-with-data-syn-sent-ack-left-edge-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-syn-sent/rcv-ack-with-data-syn-sent-ack-outside-left-ipv4.pkt
+++ b/state-event-engine/rcv-ack-syn-sent/rcv-ack-with-data-syn-sent-ack-outside-left-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-syn-sent/rcv-ack-with-data-syn-sent-ack-outside-left-ipv6.pkt
+++ b/state-event-engine/rcv-ack-syn-sent/rcv-ack-with-data-syn-sent-ack-outside-left-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-syn-sent/rcv-ack-with-data-syn-sent-ack-outside-right-ipv4.pkt
+++ b/state-event-engine/rcv-ack-syn-sent/rcv-ack-with-data-syn-sent-ack-outside-right-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-syn-sent/rcv-ack-with-data-syn-sent-ack-outside-right-ipv6.pkt
+++ b/state-event-engine/rcv-ack-syn-sent/rcv-ack-with-data-syn-sent-ack-outside-right-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-syn-sent/rcv-ack-without-data-syn-sent-ack-left-edge-ipv4.pkt
+++ b/state-event-engine/rcv-ack-syn-sent/rcv-ack-without-data-syn-sent-ack-left-edge-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-syn-sent/rcv-ack-without-data-syn-sent-ack-left-edge-ipv6.pkt
+++ b/state-event-engine/rcv-ack-syn-sent/rcv-ack-without-data-syn-sent-ack-left-edge-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-syn-sent/rcv-ack-without-data-syn-sent-ack-outside-left-ipv4.pkt
+++ b/state-event-engine/rcv-ack-syn-sent/rcv-ack-without-data-syn-sent-ack-outside-left-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-syn-sent/rcv-ack-without-data-syn-sent-ack-outside-left-ipv6.pkt
+++ b/state-event-engine/rcv-ack-syn-sent/rcv-ack-without-data-syn-sent-ack-outside-left-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-syn-sent/rcv-ack-without-data-syn-sent-ack-outside-right-ipv4.pkt
+++ b/state-event-engine/rcv-ack-syn-sent/rcv-ack-without-data-syn-sent-ack-outside-right-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-syn-sent/rcv-ack-without-data-syn-sent-ack-outside-right-ipv6.pkt
+++ b/state-event-engine/rcv-ack-syn-sent/rcv-ack-without-data-syn-sent-ack-outside-right-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-left-edge-ipv4.pkt
+++ b/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-left-edge-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-left-edge-ipv6.pkt
+++ b/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-left-edge-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-middle-ipv4.pkt
+++ b/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-middle-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-middle-ipv6.pkt
+++ b/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-middle-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-outside-left-ipv4.pkt
+++ b/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-outside-left-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-outside-left-ipv6.pkt
+++ b/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-outside-left-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-outside-right-ipv4.pkt
+++ b/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-outside-right-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-outside-right-ipv6.pkt
+++ b/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-outside-right-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-right-edge-ipv4.pkt
+++ b/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-right-edge-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-right-edge-ipv6.pkt
+++ b/state-event-engine/rcv-ack-time-wait/rcv-ack-time-wait-using-shutdown-right-edge-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-closed/rcv-fin-ack-with-data-closed-ipv4.pkt
+++ b/state-event-engine/rcv-fin-ack-closed/rcv-fin-ack-with-data-closed-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-closed/rcv-fin-ack-with-data-closed-ipv6.pkt
+++ b/state-event-engine/rcv-fin-ack-closed/rcv-fin-ack-with-data-closed-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-closed/rcv-fin-ack-without-data-closed-ipv4.pkt
+++ b/state-event-engine/rcv-fin-ack-closed/rcv-fin-ack-without-data-closed-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-closed/rcv-fin-ack-without-data-closed-ipv6.pkt
+++ b/state-event-engine/rcv-fin-ack-closed/rcv-fin-ack-without-data-closed-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-listen/rcv-fin-ack-with-data-listen-ipv4.pkt
+++ b/state-event-engine/rcv-fin-ack-listen/rcv-fin-ack-with-data-listen-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-listen/rcv-fin-ack-with-data-listen-ipv6.pkt
+++ b/state-event-engine/rcv-fin-ack-listen/rcv-fin-ack-with-data-listen-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-listen/rcv-fin-ack-without-data-listen-ipv4.pkt
+++ b/state-event-engine/rcv-fin-ack-listen/rcv-fin-ack-without-data-listen-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-listen/rcv-fin-ack-without-data-listen-ipv6.pkt
+++ b/state-event-engine/rcv-fin-ack-listen/rcv-fin-ack-without-data-listen-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-with-data-syn-sent-ack-left-edge-ipv4.pkt
+++ b/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-with-data-syn-sent-ack-left-edge-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-with-data-syn-sent-ack-left-edge-ipv6.pkt
+++ b/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-with-data-syn-sent-ack-left-edge-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-with-data-syn-sent-ack-outside-left-ipv4.pkt
+++ b/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-with-data-syn-sent-ack-outside-left-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-with-data-syn-sent-ack-outside-left-ipv6.pkt
+++ b/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-with-data-syn-sent-ack-outside-left-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-with-data-syn-sent-ack-outside-right-ipv4.pkt
+++ b/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-with-data-syn-sent-ack-outside-right-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-with-data-syn-sent-ack-outside-right-ipv6.pkt
+++ b/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-with-data-syn-sent-ack-outside-right-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-without-data-syn-sent-ack-left-edge-ipv4.pkt
+++ b/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-without-data-syn-sent-ack-left-edge-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-without-data-syn-sent-ack-left-edge-ipv6.pkt
+++ b/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-without-data-syn-sent-ack-left-edge-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-without-data-syn-sent-ack-outside-left-ipv4.pkt
+++ b/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-without-data-syn-sent-ack-outside-left-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-without-data-syn-sent-ack-outside-left-ipv6.pkt
+++ b/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-without-data-syn-sent-ack-outside-left-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-without-data-syn-sent-ack-outside-right-ipv4.pkt
+++ b/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-without-data-syn-sent-ack-outside-right-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-without-data-syn-sent-ack-outside-right-ipv6.pkt
+++ b/state-event-engine/rcv-fin-ack-syn-sent/rcv-fin-ack-without-data-syn-sent-ack-outside-right-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-left-edge-ipv4.pkt
+++ b/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-left-edge-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-left-edge-ipv6.pkt
+++ b/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-left-edge-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-middle-ipv4.pkt
+++ b/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-middle-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-middle-ipv6.pkt
+++ b/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-middle-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-outside-left-ipv4.pkt
+++ b/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-outside-left-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-outside-left-ipv6.pkt
+++ b/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-outside-left-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-outside-right-ipv4.pkt
+++ b/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-outside-right-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-outside-right-ipv6.pkt
+++ b/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-outside-right-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-right-edge-ipv4.pkt
+++ b/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-right-edge-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-right-edge-ipv6.pkt
+++ b/state-event-engine/rcv-fin-ack-time-wait/rcv-fin-ack-time-wait-using-shutdown-right-edge-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-closed/rcv-fin-with-data-closed-ipv4.pkt
+++ b/state-event-engine/rcv-fin-closed/rcv-fin-with-data-closed-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-closed/rcv-fin-with-data-closed-ipv6.pkt
+++ b/state-event-engine/rcv-fin-closed/rcv-fin-with-data-closed-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-closed/rcv-fin-without-data-closed-ipv4.pkt
+++ b/state-event-engine/rcv-fin-closed/rcv-fin-without-data-closed-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-closed/rcv-fin-without-data-closed-ipv6.pkt
+++ b/state-event-engine/rcv-fin-closed/rcv-fin-without-data-closed-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-listen/rcv-fin-with-data-listen-ipv4.pkt
+++ b/state-event-engine/rcv-fin-listen/rcv-fin-with-data-listen-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-listen/rcv-fin-with-data-listen-ipv6.pkt
+++ b/state-event-engine/rcv-fin-listen/rcv-fin-with-data-listen-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-listen/rcv-fin-without-data-listen-ipv4.pkt
+++ b/state-event-engine/rcv-fin-listen/rcv-fin-without-data-listen-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-listen/rcv-fin-without-data-listen-ipv6.pkt
+++ b/state-event-engine/rcv-fin-listen/rcv-fin-without-data-listen-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-syn-sent/rcv-fin-with-data-syn-sent-ipv4.pkt
+++ b/state-event-engine/rcv-fin-syn-sent/rcv-fin-with-data-syn-sent-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-syn-sent/rcv-fin-with-data-syn-sent-ipv6.pkt
+++ b/state-event-engine/rcv-fin-syn-sent/rcv-fin-with-data-syn-sent-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-syn-sent/rcv-fin-without-data-syn-sent-ipv4.pkt
+++ b/state-event-engine/rcv-fin-syn-sent/rcv-fin-without-data-syn-sent-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-syn-sent/rcv-fin-without-data-syn-sent-ipv6.pkt
+++ b/state-event-engine/rcv-fin-syn-sent/rcv-fin-without-data-syn-sent-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-left-edge-ipv4.pkt
+++ b/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-left-edge-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-left-edge-ipv6.pkt
+++ b/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-left-edge-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-middle-ipv4.pkt
+++ b/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-middle-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-middle-ipv6.pkt
+++ b/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-middle-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-outside-left-ipv4.pkt
+++ b/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-outside-left-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-outside-left-ipv6.pkt
+++ b/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-outside-left-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-outside-right-ipv4.pkt
+++ b/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-outside-right-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-outside-right-ipv6.pkt
+++ b/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-outside-right-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-right-edge-ipv4.pkt
+++ b/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-right-edge-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-right-edge-ipv6.pkt
+++ b/state-event-engine/rcv-fin-time-wait/rcv-fin-time-wait-using-shutdown-right-edge-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-closed/rcv-rst-ack-with-data-closed-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-closed/rcv-rst-ack-with-data-closed-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-closed/rcv-rst-ack-with-data-closed-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-closed/rcv-rst-ack-with-data-closed-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-closed/rcv-rst-ack-without-data-closed-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-closed/rcv-rst-ack-without-data-closed-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-closed/rcv-rst-ack-without-data-closed-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-closed/rcv-rst-ack-without-data-closed-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-listen/rcv-rst-ack-with-data-listen-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-listen/rcv-rst-ack-with-data-listen-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-listen/rcv-rst-ack-with-data-listen-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-listen/rcv-rst-ack-with-data-listen-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-listen/rcv-rst-ack-without-data-listen-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-listen/rcv-rst-ack-without-data-listen-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-listen/rcv-rst-ack-without-data-listen-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-listen/rcv-rst-ack-without-data-listen-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-left-edge-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-left-edge-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-left-edge-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-left-edge-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-outside-left-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-outside-left-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-outside-left-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-outside-left-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-outside-right-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-outside-right-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-outside-right-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-outside-right-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-right-edge-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-right-edge-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-right-edge-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-left-edge-ack-right-edge-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-left-edge-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-left-edge-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-left-edge-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-left-edge-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-outside-left-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-outside-left-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-outside-left-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-outside-left-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-outside-right-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-outside-right-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-outside-right-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-outside-right-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-right-edge-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-right-edge-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-right-edge-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-left-ack-right-edge-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-left-edge-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-left-edge-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-left-edge-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-left-edge-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-outside-left-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-outside-left-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-outside-left-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-outside-left-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-outside-right-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-outside-right-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-outside-right-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-outside-right-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-right-edge-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-right-edge-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-right-edge-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-outside-right-ack-right-edge-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-left-edge-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-left-edge-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-left-edge-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-left-edge-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-outside-left-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-outside-left-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-outside-left-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-outside-left-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-outside-right-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-outside-right-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-outside-right-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-outside-right-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-right-edge-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-right-edge-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-right-edge-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-listen-right-edge-ack-right-edge-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-left-edge-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-left-edge-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-left-edge-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-left-edge-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-outside-left-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-outside-left-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-outside-left-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-outside-left-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-outside-right-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-outside-right-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-outside-right-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-outside-right-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-right-edge-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-right-edge-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-right-edge-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-left-edge-ack-right-edge-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-left-edge-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-left-edge-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-left-edge-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-left-edge-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-outside-left-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-outside-left-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-outside-left-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-outside-left-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-outside-right-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-outside-right-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-outside-right-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-outside-right-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-right-edge-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-right-edge-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-right-edge-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-left-ack-right-edge-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-left-edge-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-left-edge-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-left-edge-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-left-edge-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-outside-left-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-outside-left-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-outside-left-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-outside-left-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-outside-right-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-outside-right-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-outside-right-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-outside-right-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-right-edge-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-right-edge-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-right-edge-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-outside-right-ack-right-edge-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-left-edge-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-left-edge-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-left-edge-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-left-edge-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-outside-left-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-outside-left-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-outside-left-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-outside-left-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-outside-right-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-outside-right-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-outside-right-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-outside-right-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-right-edge-insecure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-right-edge-insecure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-right-edge-secure-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-rcvd/rcv-rst-ack-syn-rcvd-via-syn-sent-right-edge-ack-right-edge-secure-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-with-data-syn-sent-ack-left-edge-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-with-data-syn-sent-ack-left-edge-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-with-data-syn-sent-ack-left-edge-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-with-data-syn-sent-ack-left-edge-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-with-data-syn-sent-ack-outside-left-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-with-data-syn-sent-ack-outside-left-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-with-data-syn-sent-ack-outside-left-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-with-data-syn-sent-ack-outside-left-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-with-data-syn-sent-ack-outside-right-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-with-data-syn-sent-ack-outside-right-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-with-data-syn-sent-ack-outside-right-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-with-data-syn-sent-ack-outside-right-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-without-data-syn-sent-ack-left-edge-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-without-data-syn-sent-ack-left-edge-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-without-data-syn-sent-ack-left-edge-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-without-data-syn-sent-ack-left-edge-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-without-data-syn-sent-ack-outside-left-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-without-data-syn-sent-ack-outside-left-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-without-data-syn-sent-ack-outside-left-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-without-data-syn-sent-ack-outside-left-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-without-data-syn-sent-ack-outside-right-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-without-data-syn-sent-ack-outside-right-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-without-data-syn-sent-ack-outside-right-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-syn-sent/rcv-rst-ack-without-data-syn-sent-ack-outside-right-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-left-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-left-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-left-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-left-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-outside-left-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-outside-left-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-outside-left-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-outside-left-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-outside-right-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-outside-right-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-outside-right-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-outside-right-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-right-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-right-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-right-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-ack-time-wait/rcv-rst-ack-time-wait-using-shutdown-right-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-left-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-left-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-left-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-left-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-outside-left-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-outside-left-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-outside-left-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-outside-left-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-outside-right-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-outside-right-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-outside-right-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-outside-right-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-right-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-right-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-right-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-close-wait/rcv-rst-close-wait-right-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closed/rcv-rst-with-data-closed-ipv4.pkt
+++ b/state-event-engine/rcv-rst-closed/rcv-rst-with-data-closed-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closed/rcv-rst-with-data-closed-ipv6.pkt
+++ b/state-event-engine/rcv-rst-closed/rcv-rst-with-data-closed-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closed/rcv-rst-without-data-closed-ipv4.pkt
+++ b/state-event-engine/rcv-rst-closed/rcv-rst-without-data-closed-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closed/rcv-rst-without-data-closed-ipv6.pkt
+++ b/state-event-engine/rcv-rst-closed/rcv-rst-without-data-closed-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closing/rcv-rst-closing-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-closing/rcv-rst-closing-left-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closing/rcv-rst-closing-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-closing/rcv-rst-closing-left-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closing/rcv-rst-closing-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-closing/rcv-rst-closing-left-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closing/rcv-rst-closing-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-closing/rcv-rst-closing-left-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closing/rcv-rst-closing-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-closing/rcv-rst-closing-outside-left-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closing/rcv-rst-closing-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-closing/rcv-rst-closing-outside-left-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closing/rcv-rst-closing-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-closing/rcv-rst-closing-outside-left-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closing/rcv-rst-closing-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-closing/rcv-rst-closing-outside-left-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closing/rcv-rst-closing-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-closing/rcv-rst-closing-outside-right-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closing/rcv-rst-closing-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-closing/rcv-rst-closing-outside-right-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closing/rcv-rst-closing-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-closing/rcv-rst-closing-outside-right-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closing/rcv-rst-closing-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-closing/rcv-rst-closing-outside-right-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closing/rcv-rst-closing-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-closing/rcv-rst-closing-right-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closing/rcv-rst-closing-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-closing/rcv-rst-closing-right-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closing/rcv-rst-closing-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-closing/rcv-rst-closing-right-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-closing/rcv-rst-closing-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-closing/rcv-rst-closing-right-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-established/rcv-rst-established-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-established/rcv-rst-established-left-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-established/rcv-rst-established-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-established/rcv-rst-established-left-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-established/rcv-rst-established-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-established/rcv-rst-established-left-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-established/rcv-rst-established-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-established/rcv-rst-established-left-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-established/rcv-rst-established-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-established/rcv-rst-established-outside-left-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-established/rcv-rst-established-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-established/rcv-rst-established-outside-left-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-established/rcv-rst-established-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-established/rcv-rst-established-outside-left-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-established/rcv-rst-established-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-established/rcv-rst-established-outside-left-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-established/rcv-rst-established-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-established/rcv-rst-established-outside-right-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-established/rcv-rst-established-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-established/rcv-rst-established-outside-right-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-established/rcv-rst-established-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-established/rcv-rst-established-outside-right-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-established/rcv-rst-established-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-established/rcv-rst-established-outside-right-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-established/rcv-rst-established-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-established/rcv-rst-established-right-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-established/rcv-rst-established-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-established/rcv-rst-established-right-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-established/rcv-rst-established-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-established/rcv-rst-established-right-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-established/rcv-rst-established-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-established/rcv-rst-established-right-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-left-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-left-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-left-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-left-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-outside-left-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-outside-left-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-outside-left-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-outside-left-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-outside-right-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-outside-right-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-outside-right-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-outside-right-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-right-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-right-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-right-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-1/rcv-rst-fin-wait-1-right-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-left-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-left-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-left-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-left-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-outside-left-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-outside-left-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-outside-left-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-outside-left-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-outside-right-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-outside-right-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-outside-right-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-outside-right-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-right-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-right-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-right-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-fin-wait-2/rcv-rst-fin-wait-2-right-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-left-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-left-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-left-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-left-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-outside-left-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-outside-left-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-outside-left-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-outside-left-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-outside-right-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-outside-right-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-outside-right-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-outside-right-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-right-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-right-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-right-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-last-ack/rcv-rst-last-ack-right-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-listen/rcv-rst-with-data-listen-ipv4.pkt
+++ b/state-event-engine/rcv-rst-listen/rcv-rst-with-data-listen-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-listen/rcv-rst-with-data-listen-ipv6.pkt
+++ b/state-event-engine/rcv-rst-listen/rcv-rst-with-data-listen-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/state-event-engine/rcv-rst-listen/rcv-rst-without-data-listen-ipv4.pkt
+++ b/state-event-engine/rcv-rst-listen/rcv-rst-without-data-listen-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/state-event-engine/rcv-rst-listen/rcv-rst-without-data-listen-ipv6.pkt
+++ b/state-event-engine/rcv-rst-listen/rcv-rst-without-data-listen-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-left-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-left-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-left-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-left-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-outside-left-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-outside-left-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-outside-left-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-outside-left-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-outside-right-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-outside-right-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-outside-right-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-outside-right-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-right-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-right-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-right-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-listen-right-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-left-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-left-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-left-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-left-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-outside-left-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-outside-left-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-outside-left-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-outside-left-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-outside-right-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-outside-right-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-outside-right-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-outside-right-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-right-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-right-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-right-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-syn-rcvd/rcv-rst-syn-rcvd-via-syn-sent-right-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-sent/rcv-rst-with-data-syn-sent-ipv4.pkt
+++ b/state-event-engine/rcv-rst-syn-sent/rcv-rst-with-data-syn-sent-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-sent/rcv-rst-with-data-syn-sent-ipv6.pkt
+++ b/state-event-engine/rcv-rst-syn-sent/rcv-rst-with-data-syn-sent-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-sent/rcv-rst-without-data-syn-sent-ipv4.pkt
+++ b/state-event-engine/rcv-rst-syn-sent/rcv-rst-without-data-syn-sent-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-syn-sent/rcv-rst-without-data-syn-sent-ipv6.pkt
+++ b/state-event-engine/rcv-rst-syn-sent/rcv-rst-without-data-syn-sent-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-left-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-left-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-left-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-left-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-outside-left-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-outside-left-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-outside-left-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-outside-left-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-outside-right-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-outside-right-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-outside-right-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-outside-right-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-right-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-right-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-right-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-rst-time-wait/rcv-rst-time-wait-using-shutdown-right-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-closed/rcv-syn-ack-with-data-closed-ipv4.pkt
+++ b/state-event-engine/rcv-syn-ack-closed/rcv-syn-ack-with-data-closed-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-closed/rcv-syn-ack-with-data-closed-ipv6.pkt
+++ b/state-event-engine/rcv-syn-ack-closed/rcv-syn-ack-with-data-closed-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-closed/rcv-syn-ack-without-data-closed-ipv4.pkt
+++ b/state-event-engine/rcv-syn-ack-closed/rcv-syn-ack-without-data-closed-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-closed/rcv-syn-ack-without-data-closed-ipv6.pkt
+++ b/state-event-engine/rcv-syn-ack-closed/rcv-syn-ack-without-data-closed-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-listen/rcv-syn-ack-with-data-listen-ipv4.pkt
+++ b/state-event-engine/rcv-syn-ack-listen/rcv-syn-ack-with-data-listen-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-listen/rcv-syn-ack-with-data-listen-ipv6.pkt
+++ b/state-event-engine/rcv-syn-ack-listen/rcv-syn-ack-with-data-listen-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-listen/rcv-syn-ack-without-data-listen-ipv4.pkt
+++ b/state-event-engine/rcv-syn-ack-listen/rcv-syn-ack-without-data-listen-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-listen/rcv-syn-ack-without-data-listen-ipv6.pkt
+++ b/state-event-engine/rcv-syn-ack-listen/rcv-syn-ack-without-data-listen-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-with-data-syn-sent-ack-left-edge-ipv4.pkt
+++ b/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-with-data-syn-sent-ack-left-edge-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-with-data-syn-sent-ack-left-edge-ipv6.pkt
+++ b/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-with-data-syn-sent-ack-left-edge-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-with-data-syn-sent-ack-outside-left-ipv4.pkt
+++ b/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-with-data-syn-sent-ack-outside-left-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-with-data-syn-sent-ack-outside-left-ipv6.pkt
+++ b/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-with-data-syn-sent-ack-outside-left-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-with-data-syn-sent-ack-outside-right-ipv4.pkt
+++ b/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-with-data-syn-sent-ack-outside-right-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-with-data-syn-sent-ack-outside-right-ipv6.pkt
+++ b/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-with-data-syn-sent-ack-outside-right-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-without-data-syn-sent-ack-left-edge-ipv4.pkt
+++ b/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-without-data-syn-sent-ack-left-edge-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-without-data-syn-sent-ack-left-edge-ipv6.pkt
+++ b/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-without-data-syn-sent-ack-left-edge-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-without-data-syn-sent-ack-outside-left-ipv4.pkt
+++ b/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-without-data-syn-sent-ack-outside-left-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-without-data-syn-sent-ack-outside-left-ipv6.pkt
+++ b/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-without-data-syn-sent-ack-outside-left-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-without-data-syn-sent-ack-outside-right-ipv4.pkt
+++ b/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-without-data-syn-sent-ack-outside-right-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-without-data-syn-sent-ack-outside-right-ipv6.pkt
+++ b/state-event-engine/rcv-syn-ack-syn-sent/rcv-syn-ack-without-data-syn-sent-ack-outside-right-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-left-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-left-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-left-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-left-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-outside-left-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-outside-left-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-outside-left-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-outside-left-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-outside-right-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-outside-right-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-outside-right-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-outside-right-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-right-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-right-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-right-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-ack-time-wait/rcv-syn-ack-time-wait-using-shutdown-right-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-left-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-left-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-left-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-left-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-outside-left-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-outside-left-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-outside-left-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-outside-left-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-outside-right-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-outside-right-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-outside-right-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-outside-right-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-right-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-right-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-right-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-close-wait/rcv-syn-close-wait-right-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closed/rcv-syn-with-data-closed-ipv4.pkt
+++ b/state-event-engine/rcv-syn-closed/rcv-syn-with-data-closed-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closed/rcv-syn-with-data-closed-ipv6.pkt
+++ b/state-event-engine/rcv-syn-closed/rcv-syn-with-data-closed-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closed/rcv-syn-without-data-closed-ipv4.pkt
+++ b/state-event-engine/rcv-syn-closed/rcv-syn-without-data-closed-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closed/rcv-syn-without-data-closed-ipv6.pkt
+++ b/state-event-engine/rcv-syn-closed/rcv-syn-without-data-closed-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closing/rcv-syn-closing-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-closing/rcv-syn-closing-left-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closing/rcv-syn-closing-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-closing/rcv-syn-closing-left-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closing/rcv-syn-closing-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-closing/rcv-syn-closing-left-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closing/rcv-syn-closing-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-closing/rcv-syn-closing-left-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closing/rcv-syn-closing-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-closing/rcv-syn-closing-outside-left-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closing/rcv-syn-closing-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-closing/rcv-syn-closing-outside-left-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closing/rcv-syn-closing-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-closing/rcv-syn-closing-outside-left-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closing/rcv-syn-closing-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-closing/rcv-syn-closing-outside-left-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closing/rcv-syn-closing-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-closing/rcv-syn-closing-outside-right-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closing/rcv-syn-closing-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-closing/rcv-syn-closing-outside-right-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closing/rcv-syn-closing-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-closing/rcv-syn-closing-outside-right-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closing/rcv-syn-closing-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-closing/rcv-syn-closing-outside-right-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closing/rcv-syn-closing-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-closing/rcv-syn-closing-right-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closing/rcv-syn-closing-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-closing/rcv-syn-closing-right-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closing/rcv-syn-closing-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-closing/rcv-syn-closing-right-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-closing/rcv-syn-closing-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-closing/rcv-syn-closing-right-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-established/rcv-syn-established-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-established/rcv-syn-established-left-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-established/rcv-syn-established-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-established/rcv-syn-established-left-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-established/rcv-syn-established-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-established/rcv-syn-established-left-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-established/rcv-syn-established-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-established/rcv-syn-established-left-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-established/rcv-syn-established-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-established/rcv-syn-established-outside-left-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-established/rcv-syn-established-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-established/rcv-syn-established-outside-left-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-established/rcv-syn-established-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-established/rcv-syn-established-outside-left-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-established/rcv-syn-established-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-established/rcv-syn-established-outside-left-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-established/rcv-syn-established-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-established/rcv-syn-established-outside-right-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-established/rcv-syn-established-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-established/rcv-syn-established-outside-right-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-established/rcv-syn-established-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-established/rcv-syn-established-outside-right-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-established/rcv-syn-established-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-established/rcv-syn-established-outside-right-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-established/rcv-syn-established-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-established/rcv-syn-established-right-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-established/rcv-syn-established-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-established/rcv-syn-established-right-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-established/rcv-syn-established-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-established/rcv-syn-established-right-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-established/rcv-syn-established-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-established/rcv-syn-established-right-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-closed/rcv-syn-fin-with-data-closed-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-closed/rcv-syn-fin-with-data-closed-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-closed/rcv-syn-fin-with-data-closed-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-closed/rcv-syn-fin-with-data-closed-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-closed/rcv-syn-fin-without-data-closed-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-closed/rcv-syn-fin-without-data-closed-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-closed/rcv-syn-fin-without-data-closed-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-closed/rcv-syn-fin-without-data-closed-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-listen/rcv-syn-fin-with-data-listen-dropping-disabled-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-listen/rcv-syn-fin-with-data-listen-dropping-disabled-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-listen/rcv-syn-fin-with-data-listen-dropping-disabled-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-listen/rcv-syn-fin-with-data-listen-dropping-disabled-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-listen/rcv-syn-fin-with-data-listen-dropping-enabled-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-listen/rcv-syn-fin-with-data-listen-dropping-enabled-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-listen/rcv-syn-fin-with-data-listen-dropping-enabled-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-listen/rcv-syn-fin-with-data-listen-dropping-enabled-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-listen/rcv-syn-fin-without-data-listen-dropping-disabled-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-listen/rcv-syn-fin-without-data-listen-dropping-disabled-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-listen/rcv-syn-fin-without-data-listen-dropping-disabled-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-listen/rcv-syn-fin-without-data-listen-dropping-disabled-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-listen/rcv-syn-fin-without-data-listen-dropping-enabled-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-listen/rcv-syn-fin-without-data-listen-dropping-enabled-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-listen/rcv-syn-fin-without-data-listen-dropping-enabled-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-listen/rcv-syn-fin-without-data-listen-dropping-enabled-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-syn-sent/rcv-syn-fin-with-data-syn-sent-dropping-disabled-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-syn-sent/rcv-syn-fin-with-data-syn-sent-dropping-disabled-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-syn-sent/rcv-syn-fin-with-data-syn-sent-dropping-disabled-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-syn-sent/rcv-syn-fin-with-data-syn-sent-dropping-disabled-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-syn-sent/rcv-syn-fin-with-data-syn-sent-dropping-enabled-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-syn-sent/rcv-syn-fin-with-data-syn-sent-dropping-enabled-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-syn-sent/rcv-syn-fin-with-data-syn-sent-dropping-enabled-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-syn-sent/rcv-syn-fin-with-data-syn-sent-dropping-enabled-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-syn-sent/rcv-syn-fin-without-data-syn-sent-dropping-disabled-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-syn-sent/rcv-syn-fin-without-data-syn-sent-dropping-disabled-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-syn-sent/rcv-syn-fin-without-data-syn-sent-dropping-disabled-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-syn-sent/rcv-syn-fin-without-data-syn-sent-dropping-disabled-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-syn-sent/rcv-syn-fin-without-data-syn-sent-dropping-enabled-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-syn-sent/rcv-syn-fin-without-data-syn-sent-dropping-enabled-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-syn-sent/rcv-syn-fin-without-data-syn-sent-dropping-enabled-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-syn-sent/rcv-syn-fin-without-data-syn-sent-dropping-enabled-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-left-edge-insecure-drop-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-left-edge-insecure-drop-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-left-edge-insecure-drop-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-left-edge-insecure-drop-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-left-edge-insecure-nodrop-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-left-edge-insecure-nodrop-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-left-edge-insecure-nodrop-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-left-edge-insecure-nodrop-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-left-edge-secure-drop-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-left-edge-secure-drop-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-left-edge-secure-drop-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-left-edge-secure-drop-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-left-edge-secure-nodrop-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-left-edge-secure-nodrop-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-left-edge-secure-nodrop-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-left-edge-secure-nodrop-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-left-insecure-drop-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-left-insecure-drop-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-left-insecure-drop-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-left-insecure-drop-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-left-insecure-nodrop-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-left-insecure-nodrop-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-left-insecure-nodrop-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-left-insecure-nodrop-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-left-secure-drop-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-left-secure-drop-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-left-secure-drop-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-left-secure-drop-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-left-secure-nodrop-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-left-secure-nodrop-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-left-secure-nodrop-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-left-secure-nodrop-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-right-insecure-drop-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-right-insecure-drop-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-right-insecure-drop-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-right-insecure-drop-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-right-insecure-nodrop-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-right-insecure-nodrop-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-right-insecure-nodrop-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-right-insecure-nodrop-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-right-secure-drop-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-right-secure-drop-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-right-secure-drop-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-right-secure-drop-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-right-secure-nodrop-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-right-secure-nodrop-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-right-secure-nodrop-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-outside-right-secure-nodrop-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-right-edge-insecure-drop-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-right-edge-insecure-drop-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-right-edge-insecure-drop-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-right-edge-insecure-drop-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-right-edge-insecure-nodrop-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-right-edge-insecure-nodrop-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-right-edge-insecure-nodrop-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-right-edge-insecure-nodrop-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-right-edge-secure-drop-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-right-edge-secure-drop-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-right-edge-secure-drop-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-right-edge-secure-drop-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-right-edge-secure-nodrop-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-right-edge-secure-nodrop-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-right-edge-secure-nodrop-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-time-wait/rcv-syn-fin-time-wait-using-shutdown-right-edge-secure-nodrop-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-left-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-left-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-left-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-left-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-outside-left-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-outside-left-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-outside-left-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-outside-left-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-outside-right-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-outside-right-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-outside-right-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-outside-right-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-right-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-right-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-right-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-1/rcv-syn-fin-wait-1-right-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-left-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-left-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-left-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-left-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-outside-left-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-outside-left-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-outside-left-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-outside-left-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-outside-right-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-outside-right-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-outside-right-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-outside-right-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-right-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-right-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-right-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-fin-wait-2/rcv-syn-fin-wait-2-right-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-left-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-left-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-left-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-left-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-outside-left-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-outside-left-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-outside-left-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-outside-left-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-outside-right-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-outside-right-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-outside-right-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-outside-right-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-right-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-right-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-right-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-last-ack/rcv-syn-last-ack-right-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-listen/rcv-syn-with-data-listen-ipv4.pkt
+++ b/state-event-engine/rcv-syn-listen/rcv-syn-with-data-listen-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-listen/rcv-syn-with-data-listen-ipv6.pkt
+++ b/state-event-engine/rcv-syn-listen/rcv-syn-with-data-listen-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-listen/rcv-syn-without-data-listen-ipv4.pkt
+++ b/state-event-engine/rcv-syn-listen/rcv-syn-without-data-listen-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-listen/rcv-syn-without-data-listen-ipv6.pkt
+++ b/state-event-engine/rcv-syn-listen/rcv-syn-without-data-listen-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-syn-sent/rcv-syn-with-data-syn-sent-ipv4.pkt
+++ b/state-event-engine/rcv-syn-syn-sent/rcv-syn-with-data-syn-sent-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-syn-sent/rcv-syn-with-data-syn-sent-ipv6.pkt
+++ b/state-event-engine/rcv-syn-syn-sent/rcv-syn-with-data-syn-sent-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-syn-sent/rcv-syn-without-data-syn-sent-ipv4.pkt
+++ b/state-event-engine/rcv-syn-syn-sent/rcv-syn-without-data-syn-sent-ipv4.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-syn-sent/rcv-syn-without-data-syn-sent-ipv6.pkt
+++ b/state-event-engine/rcv-syn-syn-sent/rcv-syn-without-data-syn-sent-ipv6.pkt
@@ -33,6 +33,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-left-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-left-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-left-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-left-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-left-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-left-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-left-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-left-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-outside-left-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-outside-left-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-outside-left-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-outside-left-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-outside-left-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-outside-left-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-outside-left-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-outside-left-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-outside-right-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-outside-right-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-outside-right-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-outside-right-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-outside-right-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-outside-right-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-outside-right-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-outside-right-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-right-edge-insecure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-right-edge-insecure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-right-edge-insecure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-right-edge-insecure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-right-edge-secure-ipv4.pkt
+++ b/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-right-edge-secure-ipv4.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-right-edge-secure-ipv6.pkt
+++ b/state-event-engine/rcv-syn-time-wait/rcv-syn-time-wait-using-shutdown-right-edge-secure-ipv6.pkt
@@ -32,6 +32,7 @@
 
 // Ensure that all relevant sysctl variables have their default values.
  0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w kern.ipc.maxsockbuf=2097152`

--- a/tcp-over-udp/active-connection-setup-ipv4.pkt
+++ b/tcp-over-udp/active-connection-setup-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/active-connection-setup-ipv6.pkt
+++ b/tcp-over-udp/active-connection-setup-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/getsockopt-tcp-maxseg-established-ipv4.pkt
+++ b/tcp-over-udp/getsockopt-tcp-maxseg-established-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/getsockopt-tcp-maxseg-established-ipv6.pkt
+++ b/tcp-over-udp/getsockopt-tcp-maxseg-established-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/passive-connection-setup-ipv4.pkt
+++ b/tcp-over-udp/passive-connection-setup-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/passive-connection-setup-ipv6.pkt
+++ b/tcp-over-udp/passive-connection-setup-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-ack-closing-ipv4.pkt
+++ b/tcp-over-udp/rcv-ack-closing-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-ack-closing-ipv6.pkt
+++ b/tcp-over-udp/rcv-ack-closing-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-ack-finwait-1-ipv4.pkt
+++ b/tcp-over-udp/rcv-ack-finwait-1-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-ack-finwait-1-ipv6.pkt
+++ b/tcp-over-udp/rcv-ack-finwait-1-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-ack-last-ack-ipv4.pkt
+++ b/tcp-over-udp/rcv-ack-last-ack-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-ack-last-ack-ipv6.pkt
+++ b/tcp-over-udp/rcv-ack-last-ack-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-ack-syn-rcvd-syn-cache-ipv4.pkt
+++ b/tcp-over-udp/rcv-ack-syn-rcvd-syn-cache-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-ack-syn-rcvd-syn-cache-ipv6.pkt
+++ b/tcp-over-udp/rcv-ack-syn-rcvd-syn-cache-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-ack-syn-rcvd-syn-cookie-ipv4.pkt
+++ b/tcp-over-udp/rcv-ack-syn-rcvd-syn-cookie-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-ack-syn-rcvd-syn-cookie-ipv6.pkt
+++ b/tcp-over-udp/rcv-ack-syn-rcvd-syn-cookie-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-ack-syn-rcvd-via-syn-sent-ipv4.pkt
+++ b/tcp-over-udp/rcv-ack-syn-rcvd-via-syn-sent-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-ack-syn-rcvd-via-syn-sent-ipv6.pkt
+++ b/tcp-over-udp/rcv-ack-syn-rcvd-via-syn-sent-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-ack-timewait-ipv4.pkt
+++ b/tcp-over-udp/rcv-ack-timewait-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-ack-timewait-ipv6.pkt
+++ b/tcp-over-udp/rcv-ack-timewait-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-fin-estab-ipv4.pkt
+++ b/tcp-over-udp/rcv-fin-estab-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-fin-estab-ipv6.pkt
+++ b/tcp-over-udp/rcv-fin-estab-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-fin-finwait-1-ipv4.pkt
+++ b/tcp-over-udp/rcv-fin-finwait-1-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-fin-finwait-1-ipv6.pkt
+++ b/tcp-over-udp/rcv-fin-finwait-1-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-fin-finwait-2-ipv4.pkt
+++ b/tcp-over-udp/rcv-fin-finwait-2-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-fin-finwait-2-ipv6.pkt
+++ b/tcp-over-udp/rcv-fin-finwait-2-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-fin-timewait-ipv4.pkt
+++ b/tcp-over-udp/rcv-fin-timewait-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-fin-timewait-ipv6.pkt
+++ b/tcp-over-udp/rcv-fin-timewait-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-icmp-admin-prohibited-syn-sent-ipv6.pkt
+++ b/tcp-over-udp/rcv-icmp-admin-prohibited-syn-sent-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-icmp-fragmentation-needed-established-ipv4.pkt
+++ b/tcp-over-udp/rcv-icmp-fragmentation-needed-established-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-icmp-host-prohibited-syn-sent-ipv4.pkt
+++ b/tcp-over-udp/rcv-icmp-host-prohibited-syn-sent-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-icmp-net-prohibited-syn-sent-ipv4.pkt
+++ b/tcp-over-udp/rcv-icmp-net-prohibited-syn-sent-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-icmp-packet-too-big-established-ipv6.pkt
+++ b/tcp-over-udp/rcv-icmp-packet-too-big-established-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-icmp-port-unreachable-syn-sent-ipv4.pkt
+++ b/tcp-over-udp/rcv-icmp-port-unreachable-syn-sent-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-icmp-port-unreachable-syn-sent-ipv6.pkt
+++ b/tcp-over-udp/rcv-icmp-port-unreachable-syn-sent-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-rst-encaps-syn-sent-ipv4.pkt
+++ b/tcp-over-udp/rcv-rst-encaps-syn-sent-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-rst-encaps-syn-sent-ipv6.pkt
+++ b/tcp-over-udp/rcv-rst-encaps-syn-sent-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-rst-plain-syn-sent-ipv4.pkt
+++ b/tcp-over-udp/rcv-rst-plain-syn-sent-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-rst-plain-syn-sent-ipv6.pkt
+++ b/tcp-over-udp/rcv-rst-plain-syn-sent-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-syn-ack-syn-sent-ipv4.pkt
+++ b/tcp-over-udp/rcv-syn-ack-syn-sent-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-syn-ack-syn-sent-ipv6.pkt
+++ b/tcp-over-udp/rcv-syn-ack-syn-sent-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-syn-closed-ipv4.pkt
+++ b/tcp-over-udp/rcv-syn-closed-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-syn-closed-ipv6.pkt
+++ b/tcp-over-udp/rcv-syn-closed-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-syn-timewait-ipv4.pkt
+++ b/tcp-over-udp/rcv-syn-timewait-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/rcv-syn-timewait-ipv6.pkt
+++ b/tcp-over-udp/rcv-syn-timewait-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/setsockopt-ipv6-use-min-mtu-closed-ipv6.pkt
+++ b/tcp-over-udp/setsockopt-ipv6-use-min-mtu-closed-ipv6.pkt
@@ -35,6 +35,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/setsockopt-remote-udp-encaps-port-closed-ipv4.pkt
+++ b/tcp-over-udp/setsockopt-remote-udp-encaps-port-closed-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/setsockopt-remote-udp-encaps-port-closed-ipv6.pkt
+++ b/tcp-over-udp/setsockopt-remote-udp-encaps-port-closed-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/setsockopt-remote-udp-encaps-port-listen-ipv4.pkt
+++ b/tcp-over-udp/setsockopt-remote-udp-encaps-port-listen-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/setsockopt-remote-udp-encaps-port-listen-ipv6.pkt
+++ b/tcp-over-udp/setsockopt-remote-udp-encaps-port-listen-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/setsockopt-remote-udp-encaps-port-syn-sent-ipv4.pkt
+++ b/tcp-over-udp/setsockopt-remote-udp-encaps-port-syn-sent-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/setsockopt-remote-udp-encaps-port-syn-sent-ipv6.pkt
+++ b/tcp-over-udp/setsockopt-remote-udp-encaps-port-syn-sent-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/setsockopt-tcp-maxseg-established-ipv4.pkt
+++ b/tcp-over-udp/setsockopt-tcp-maxseg-established-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/setsockopt-tcp-maxseg-established-ipv6.pkt
+++ b/tcp-over-udp/setsockopt-tcp-maxseg-established-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.recvspace=65536`

--- a/tcp-over-udp/sysctl-pmtud-blackhole-detection-ipv4.pkt
+++ b/tcp-over-udp/sysctl-pmtud-blackhole-detection-ipv4.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.pmtud_blackhole_mss=1200`

--- a/tcp-over-udp/sysctl-pmtud-blackhole-detection-ipv6.pkt
+++ b/tcp-over-udp/sysctl-pmtud-blackhole-detection-ipv6.pkt
@@ -31,6 +31,7 @@
  0.00 `sysctl -w net.inet.tcp.syncookies_only=0`
 +0.00 `sysctl -w net.inet.tcp.syncookies=1`
 +0.00 `sysctl -w net.inet.tcp.rfc1323=1`
++0.00 `sysctl -w net.inet.tcp.blackhole=0`
 +0.00 `sysctl -w net.inet.tcp.sack.enable=1`
 +0.00 `sysctl -w net.inet.tcp.ecn.enable=2`
 +0.00 `sysctl -w net.inet.tcp.v6pmtud_blackhole_mss=1220`


### PR DESCRIPTION
Disable it everywhere, but all those tests will fails if enabled:

-  rcv_ack_closing_ipv4
-  rcv_ack_closing_ipv6
-  rcv_ack_finwait_1_ipv4
-  rcv_ack_finwait_1_ipv6
-  rcv_ack_last_ack_ipv4
-  rcv_ack_last_ack_ipv6
-  rcv_ack_syn_rcvd_via_syn_sent_ipv4
-  rcv_ack_syn_rcvd_via_syn_sent_ipv6
-  rcv_ack_with_data_closed_ipv4
-  rcv_ack_with_data_closed_ipv6
-  rcv_ack_without_data_closed_ipv4
-  rcv_ack_without_data_closed_ipv6
-  rcv_fin_ack_with_data_closed_ipv4
-  rcv_fin_ack_with_data_closed_ipv6
-  rcv_fin_ack_without_data_closed_ipv4
-  rcv_fin_ack_without_data_closed_ipv6
-  rcv_fin_estab_ipv4
-  rcv_fin_estab_ipv6
-  rcv_fin_finwait_1_ipv4
-  rcv_fin_finwait_1_ipv6
-  rcv_fin_finwait_2_ipv4
-  rcv_fin_finwait_2_ipv6
-  rcv_fin_with_data_closed_ipv4
-  rcv_fin_with_data_closed_ipv6
-  rcv_fin_without_data_closed_ipv4
-  rcv_fin_without_data_closed_ipv6
-  rcv_syn_ack_syn_sent_ipv4
-  rcv_syn_ack_syn_sent_ipv6
-  rcv_syn_ack_with_data_closed_ipv4
-  rcv_syn_ack_with_data_closed_ipv6
-  rcv_syn_ack_without_data_closed_ipv4
-  rcv_syn_ack_without_data_closed_ipv6
-  rcv_syn_closed_ipv4
-  rcv_syn_closed_ipv6
-  rcv_syn_fin_with_data_closed_ipv4
-  rcv_syn_fin_with_data_closed_ipv6
-  rcv_syn_fin_without_data_closed_ipv4
-  rcv_syn_fin_without_data_closed_ipv6
-  rcv_syn_with_data_closed_ipv4
-  rcv_syn_with_data_closed_ipv6
-  rcv_syn_without_data_closed_ipv4
-  rcv_syn_without_data_closed_ipv6
-  socket_api_setsockopt_hoplimit_active_ipv6
-  socket_api_setsockopt_hoplimit_passive_ipv6
-  socket_api_setsockopt_tos_active_ipv4
-  socket_api_setsockopt_tos_passive_ipv4
-  socket_api_setsockopt_traffic_class_active_ipv6
-  socket_api_setsockopt_traffic_class_passive_ipv6
-  socket_api_setsockopt_ttl_active_ipv4
-  socket_api_setsockopt_ttl_passive_ipv4